### PR TITLE
add a WaitFor function

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.8: QmSXpwmggGd8fe7e9abqRuST7SqaZjrz3Cg5avMJbdmKGe
+1.1.9: QmYazuWNCrC7LXeRt3utQuRsCDufpNM176rD1efuvF2pWJ

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   "license": "MIT",
   "name": "go-testutil",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.8"
+  "version": "1.1.9"
 }
 

--- a/util.go
+++ b/util.go
@@ -1,0 +1,21 @@
+package testutil
+
+import (
+	"context"
+	"time"
+)
+
+// WaitFor waits for `check` to stop returning an error or for the context to be
+// canceled (whichever comes first).
+func WaitFor(ctx context.Context, check func() error) error {
+	for {
+		time.Sleep(time.Millisecond * 10)
+		err := check()
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return err
+		}
+	}
+}


### PR DESCRIPTION
WaitFor allows one to repeatedly poll a function until it stops erroring or the
context expires.