### PR TITLE
Use 1024-bit RSA keys

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -146,7 +146,7 @@ func RandPeerNetParams() (*PeerNetParams, error) {
 	var p PeerNetParams
 	var err error
 	p.Addr = ZeroLocalTCPAddress
-	p.PrivKey, p.PubKey, err = RandTestKeyPair(512)
+	p.PrivKey, p.PubKey, err = RandTestKeyPair(1024)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
512-bit keys are too small to do RSA-PSS with, which breaks TLS 1.3.