### PR TITLE
misc: remove RandCidV0 from this package

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	cid "github.com/ipfs/go-cid"
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	ptest "github.com/libp2p/go-libp2p-peer/test"
@@ -47,12 +46,6 @@ func RandPeerID() (peer.ID, error) {
 	rand.Read(buf)
 	h, _ := mh.Sum(buf, mh.SHA2_256, -1)
 	return peer.ID(h), nil
-}
-
-func RandCidV0() (*cid.Cid, error) {
-	buf := make([]byte, 16)
-	rand.Read(buf)
-	return cid.NewCidV0(buf), nil
 }
 
 func RandPeerIDFatal(t testing.TB) peer.ID {

--- a/package.json
+++ b/package.json
@@ -35,12 +35,6 @@
       "hash": "QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua",
       "name": "go-multihash",
       "version": "1.0.7"
-    },
-    {
-      "author": "whyrusleeping",
-      "hash": "QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY",
-      "name": "go-cid",
-      "version": "0.7.20"
     }
   ],
   "gxVersion": "0.8.0",


### PR DESCRIPTION
It bloats up dependency tree of go-cid.
I will add very similar function to cid package.